### PR TITLE
Pass forward reasons so that we can avoid infinite loops

### DIFF
--- a/src/step-checker/__tests__/equation-checker.test.ts
+++ b/src/step-checker/__tests__/equation-checker.test.ts
@@ -6,7 +6,7 @@ import StepChecker from "../step-checker";
 const checker = new StepChecker();
 
 const checkStep = (prev: Semantic.Expression, next: Semantic.Expression) =>
-    checker.checkStep(prev, next);
+    checker.checkStep(prev, next, []);
 
 describe("EquationChecker", () => {
     describe("adding the same value to both sides", () => {

--- a/src/step-checker/__tests__/fraction-checker.test.ts
+++ b/src/step-checker/__tests__/fraction-checker.test.ts
@@ -6,7 +6,7 @@ import StepChecker from "../step-checker";
 const checker = new StepChecker();
 
 const checkStep = (prev: Semantic.Expression, next: Semantic.Expression) =>
-    checker.checkStep(prev, next);
+    checker.checkStep(prev, next, []);
 
 describe("FractionChecker", () => {
     it("1 -> a/a", () => {
@@ -347,6 +347,88 @@ describe("FractionChecker", () => {
         expect(result.equivalent).toBe(true);
         expect(result.reasons.map(reason => reason.message)).toEqual([
             "division by one",
+        ]);
+    });
+
+    // TODO: make sure distribution is including substeps
+    // e.g. 1/c * a + 1/c * b
+    it.skip("1/c * (a + b) -> a/c + b/c", () => {
+        const before = parse("1/c * (a + b)");
+        const after = parse("a/c  + b/c");
+
+        const result = checkStep(before, after);
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "distribution",
+        ]);
+    });
+
+    // TODO: make sure factoring is including substeps
+    // e.g. 1/c * a + 1/c * b
+    it.skip("a/c + b/c -> 1/c * (a + b)", () => {
+        const before = parse("a/c  + b/c");
+        const after = parse("1/c * (a + b)");
+
+        const result = checkStep(before, after);
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "factoring",
+        ]);
+    });
+
+    // TODO: make this pass
+    it.skip("(a + b) / c -> a/c + b/c", () => {
+        const before = parse("(a + b) / c");
+        const after = parse("a/c  + b/c");
+
+        const result = checkStep(before, after);
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "division by one",
+        ]);
+    });
+
+    // TODO: make this pass
+    it.skip("a/c + b/c -> a + b) / c", () => {
+        const before = parse("a/c  + b/c");
+        const after = parse("(a + b) / c");
+
+        const result = checkStep(before, after);
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "division by one",
+        ]);
+    });
+
+    // TODO: this should be a single step
+    it.skip("a * 1/b -> a/b", () => {
+        const before = parse("a * 1/b");
+        const after = parse("a/b");
+
+        const result = checkStep(before, after);
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "multiplying fractions",
+            "multiplication with identity",
+        ]);
+    });
+
+    // TODO: this should be a single step
+    it.skip("a/b -> a * 1/b", () => {
+        const after = parse("a * 1/b");
+        const before = parse("a/b");
+
+        const result = checkStep(before, after);
+
+        expect(result.equivalent).toBe(true);
+        expect(result.reasons.map(reason => reason.message)).toEqual([
+            "multiplying fractions",
+            "multiplication with identity",
         ]);
     });
 });

--- a/src/step-checker/__tests__/integer-checker.test.ts
+++ b/src/step-checker/__tests__/integer-checker.test.ts
@@ -8,7 +8,7 @@ import {Result} from "../step-checker";
 const checker = new StepChecker();
 
 const checkStep = (prev: string, next: string) => {
-    return checker.checkStep(parse(prev), parse(next));
+    return checker.checkStep(parse(prev), parse(next), []);
 };
 
 expect.extend({

--- a/src/step-checker/__tests__/step-checker.test.ts
+++ b/src/step-checker/__tests__/step-checker.test.ts
@@ -6,7 +6,7 @@ import StepChecker from "../step-checker";
 const checker = new StepChecker();
 
 const checkStep = (prev: Semantic.Expression, next: Semantic.Expression) =>
-    checker.checkStep(prev, next);
+    checker.checkStep(prev, next, []);
 
 // TODO: create a test helper
 // TODO: rename checkStep to isEquivalent


### PR DESCRIPTION
The issue is that some the step checkers can end up reversing the step we're in the process of checking which causes an infinite loop.  This PR lays the ground work to prevent this from happening.